### PR TITLE
Add simulated base IMU with noise terms

### DIFF
--- a/src/bullet_utils/env.py
+++ b/src/bullet_utils/env.py
@@ -58,6 +58,9 @@ class BulletEnv(object):
             time.sleep(self.dt)
         pybullet.stepSimulation()
 
+        for robot in self.robots:
+            robot.compute_numerical_quantities(self.dt)
+            
     def print_physics_engine_params(self):
         params = pybullet.getPhysicsEngineParameters(self.physicsClient)
         print("physics_engine_params:")


### PR DESCRIPTION
## Description

This small PR adds a simulated base IMU which provides 3d gyroscope and 3d accelerometer measurements including noise terms. The gyroscope data is computed as the base angular velocity in base frame plus noise, while the accelerometer data as the base acceleration (differentiated numerically from base linear velocity) with negative gravity added, rotated into base frame plus noise.

The noise terms include those most commonly observed in MEMS sensors: 3d gyroscope bias, 3d gyroscope thermal noise, 3d accelerometer bias, and 3d accelerometer noise. The bias terms are modeled as Brownian motion (random walk), computed by integrating Gaussian white noise having known standard deviation (discretized using the simulation timestep). The thermal noise is modeled as additive Gaussian white noise having known standard deviation (also discretized as above). The continuous noise term standard deviations are set to nominal values based on an older IMU (Microstrain 3DM-GX3-25) using in Rotella 2014 as an example.

I had intended to write a more general simulated IMU class which could be associated with any link and with a relative pose offset to that link (as we discussed) but wanted to get something implemented for now, so I settled on a simple base IMU assumed to be pose-aligned with the base link.

## How I Tested

The COM control task in blmc_controllers was modified to perform a fast sinusoidal squatting motion. The simulated IMU getter functions added in this PR were used to obtain sensor data, which was recorded to a pkl file using the DataCollector class. Data was analyzed in RAI using the built-in signal differentation functionality to confirm that the numerical acceleration matches differentiated velocity as expected, as well as to verify that the noise terms are functioning properly. 

Note that the effect of the biases cannot be seen clearly unless the continuous noise values are increased drastically; IMU bias terms grow very slowly over long periods of operation.