### PR TITLE
fix_inconsistent_inertia_link_frame

### DIFF
--- a/demos/demo_simulate_a_robot.py
+++ b/demos/demo_simulate_a_robot.py
@@ -20,7 +20,11 @@ import pinocchio
 
 from bullet_utils.env import BulletEnvWithGround
 from robot_properties_solo.solo8wrapper import Solo8Robot
-import importlib.resources
+try:
+    # use standard Python importlib if available (Python>3.7)
+    import importlib.resources as importlib_resources
+except ImportError:
+    import importlib_resources
 
 if __name__ == "__main__":
     np.set_printoptions(precision=2, suppress=True)

--- a/demos/demo_simulate_a_robot.py
+++ b/demos/demo_simulate_a_robot.py
@@ -20,11 +20,6 @@ import pinocchio
 
 from bullet_utils.env import BulletEnvWithGround
 from robot_properties_solo.solo8wrapper import Solo8Robot
-try:
-    # use standard Python importlib if available (Python>3.7)
-    import importlib.resources as importlib_resources
-except ImportError:
-    import importlib_resources
 
 if __name__ == "__main__":
     np.set_printoptions(precision=2, suppress=True)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."
The PR is to address issue #5.

## How I Tested

[//]: # "Explain how you tested your changes"
Test it by running `python3 demos/demo_simulate_a_robot.py` and change the base_link inertia in `solo8.urdf`:

With default `solo8.urdf` and current code, the output of `q[:3]` is  [0, 0, 0.4].
With default `solo8.urdf` and revised code, the output of `q[:3]` is  [0, 0, 0.4].

By changing urdf `solo8.urdf` to simulate the inconsistent inertia frame and link frame scenario :
```
<robot name="solo" xmlns:controller="http://playerstage.sourceforge.net/gazebo/xmlschema/#controller" xmlns:interface="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" xmlns:sensor="http://playerstage.sourceforge.net/gazebo/xmlschema/#sensor" xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface">
  <!-- This file is based on: https://atlas.is.localnet/confluence/display/AMDW/Quadruped+URDF+Files -->
  <link name="base_link">
    <!-- BASE LINK INERTIAL -->
    <inertial>
      <origin rpy="0 0 0" xyz="0 0 **-1**"/>
      <mass value="1.43315091"/>
      <!-- The base is extremely symmetrical. -->
      <inertia ixx="0.00578574" ixy="0.0" ixz="0.0" iyy="0.01938108" iyz="0.0" izz="0.02476124"/>
    </inertial>
     ...
   </link>
...
</robot>
```
With revised `solo8.urdf` and current code, the output of `q[:3]` is  [0, 0, -0.6].
With revised `solo8.urdf` and revised code, the output of `q[:3]` is  [0, 0, 0.4].

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] link to dependent pull request

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
