### PR TITLE
Change the default behavior for `env.step(sleep)` from `True` to `False`

### DIFF
--- a/src/bullet_utils/env.py
+++ b/src/bullet_utils/env.py
@@ -83,7 +83,7 @@ class BulletEnv(object):
                 pybullet.STATE_LOGGING_VIDEO_MP4, self.file_name
             )
 
-    def step(self, sleep=True):
+    def step(self, sleep=False):
         """Integrates the simulation one step forward.
 
         Args:


### PR DESCRIPTION
I propose to change the default of `env.step` from sleeping by default to not sleeping by default. The reason is that as a new user you might not know that there is a sleep functionality and as such think the simulation is running very slow.

We ran into this problem recently.