### PR TITLE
Hammoud/bulletwrapper_get_force()

### DIFF
--- a/demos/demo_simulate_a_robot.py
+++ b/demos/demo_simulate_a_robot.py
@@ -44,7 +44,9 @@ if __name__ == "__main__":
         #  q, dq = robot.get_state_update_pinocchio()
 
         if i % 100 == 0:
-            print("Forces:", active_contact_frames, contact_forces)
+            print("Contact status :\n", active_contact_frames)
+            print("Corresponding forces :\n", contact_forces)
+            # print("Forces:", active_contact_frames, contact_forces)
 
         # Compute the command torques at the joints. The torque
         # vector only takes the actuated joints (excluding the base)

--- a/demos/demo_simulate_a_robot.py
+++ b/demos/demo_simulate_a_robot.py
@@ -24,7 +24,8 @@ from robot_properties_solo.solo8wrapper import Solo8Robot
 if __name__ == "__main__":
     np.set_printoptions(precision=2, suppress=True)
     env = BulletEnvWithGround(pybullet.GUI)
-    robot = env.add_robot(Solo8Robot)
+    robot = Solo8Robot()
+    env.add_robot(robot)
     q, dq = robot.get_state()
 
     # Update the simulation state to the new initial configuration.

--- a/demos/demo_simulate_a_robot.py
+++ b/demos/demo_simulate_a_robot.py
@@ -61,5 +61,5 @@ if __name__ == "__main__":
     # Print the final active force frames and the forces
     force_frames, forces = robot.get_force()
 
-    print("Active force_frames:", force_frames)
-    print("Corresponding forces:", forces)
+    print("Active force_frames:\n", force_frames)
+    print("Corresponding forces:\n", forces)

--- a/src/bullet_utils/wrapper.py
+++ b/src/bullet_utils/wrapper.py
@@ -117,6 +117,10 @@ class PinBulletWrapper(object):
         self.pinocchio_endeff_ids = [
             pinocchio_robot.model.getFrameId(name) for name in endeff_names
         ]
+        # 
+        self.nb_contacts = len(self.pinocchio_endeff_ids)
+        self.contact_status = np.zeros(self.nb_contacts)
+        self.contact_forces = np.zeros([self.nb_contacts, 6])
 
     def get_force(self):
         """Returns the force readings as well as the set of active contacts
@@ -129,8 +133,9 @@ class PinBulletWrapper(object):
         active_contacts_frame_ids = []
         contact_forces = []
 
+
         # Get the contact model using the pybullet.getContactPoints() api.
-        cp = pybullet.getContactPoints()
+        cp = pybullet.getContactPoints(self.robot_id)
 
         for ci in reversed(cp):
             contact_normal = ci[7]

--- a/src/bullet_utils/wrapper.py
+++ b/src/bullet_utils/wrapper.py
@@ -129,13 +129,8 @@ class PinBulletWrapper(object):
             (:obj:`list` of :obj:`int`): List of active contact frame ids.
             (:obj:`list` of np.array((6,1))) List of active contact forces.
         """        
-        
-        active_contacts_frame_ids = []
-        contact_forces = []
-
         self.contact_status.fill(0.)
         self.contact_forces.fill(0.)
-
         # Get the contact model using the pybullet.getContactPoints() api.
         cp = pybullet.getContactPoints(self.robot_id)
 
@@ -149,14 +144,9 @@ class PinBulletWrapper(object):
 
             if ci[3] in self.bullet_endeff_ids:
                 i = np.where(np.array(self.bullet_endeff_ids) == ci[3])[0][0]
-            elif ci[4] in self.bullet_endeff_ids:
-                i = np.where(np.array(self.bullet_endeff_ids) == ci[4])[0][0]
             else:
-                continue
-
-            if self.pinocchio_endeff_ids[i] in active_contacts_frame_ids:
-                continue
-            
+                continue 
+             
             self.contact_status[i] = 1 
             self.contact_forces[i,:3] = normal_force * np.array(contact_normal) \
                 + lateral_friction_force_1 * np.array(lateral_friction_direction_1) \


### PR DESCRIPTION
This pull request includes minor fixes and modifications to `PinBulletWrapper` 
here are the changes

1. modify the demo to match updated `robot_properties_solo` 
2. modify `PinBulletWrapper.get_force()`  to return the correct direction of the force, before, the order of the bodies in `pyBullet.getContactPoints` would choose the robot as bodyB 
3. modify `PinBulletWrapper.get_force()` to return the forces for all end-effectors, non-active  end-effectors get zero force and zero active status. 

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

[//]: # "Explain how you tested your changes"


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] link to dependent pull request

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
